### PR TITLE
Add option to exclude metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ A fully functioning monitoring component for [Duckula](https://github.com/nomnom
 
 Only useful if you're using Duckula :wink:
 
+
+## Options
+
+
+- `name`: (optional) name of the monitoring stack, usually will be the name of your service, used only for lifecylce logs
+- `exclude-pattern`:  (optional) a Regex  to filter out metrics that you don't want to report on, e.g health-check routes, it will also switch logs to DEBUG only level. Note that exceptions thrown will always be tracked and reported!
+
+
+
 ## Usage
 
 ```clojure
@@ -23,7 +32,7 @@ Only useful if you're using Duckula :wink:
    :statsd (stature.metrics/create {:host "localhost" :port 8125 :prefix "duckula-test"})
    ;; put it all together
    :monitoring (component/using
-                (duckula.monitoring/create {:name "my-api"})
+                (duckula.monitoring/create {:name "my-api" :exclude-pattern #".+health-check.+"})
                 [:statsd :exception-tracker])
    ;; sets up the web request handler
   ;; ring-compatible web server component must be provided by you

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Only useful if you're using Duckula :wink:
 
 ```
 
+## Changelog
+
+
+- [2020-03-25] - Add `exclude-pattern` options
+
+- [2019-10-21] - Initial Public Offering
+
 ## Roadmap
 
 None at the moment

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/duckula.monitoring "0.5.0"
+(defproject nomnom/duckula.monitoring "0.6.0-SNAPSHOT"
   :description "Monitoring Component for Duckula"
   :url "https://github.com/nomnom-insights/nomnom.duckula.monitoring"
   :license {:name "MIT License"

--- a/src/duckula/monitoring.clj
+++ b/src/duckula/monitoring.clj
@@ -1,11 +1,23 @@
 (ns duckula.monitoring
-  (:require [duckula.protocol]
-            [clojure.tools.logging :as log]
-            [caliban.tracker.protocol :as tracker]
-            [stature.metrics.protocol :as stature]
-            [com.stuartsierra.component :as component]))
+  (:require
+    [caliban.tracker.protocol :as tracker]
+    [clojure.tools.logging :as log]
+    [com.stuartsierra.component :as component]
+    [duckula.protocol]
+    [stature.metrics.protocol :as stature])
+  (:import
+    (java.util.regex
+      Pattern)))
 
-(defrecord Monitoring [name exception-tracker statsd]
+
+(defn should-report?
+  [exclude-pattern key]
+  (not (and exclude-pattern (re-find exclude-pattern key))))
+
+
+(defrecord Monitoring
+  [name exclude-pattern exception-tracker statsd]
+
   component/Lifecycle
   (start [this]
     (log/infof "monitoring=%s start" name)
@@ -13,27 +25,66 @@
   (stop [this]
     (log/warnf "monitoring=%s stop" name)
     this)
+
+
   duckula.protocol/Monitoring
-  (record-timing [this key time-ms]
-    (log/infof "request=%s time=%s" key time-ms)
-    (stature/timing statsd key time-ms))
-  (on-success [this key response]
-    (log/infof "request=%s status=success:%s" key (:status response))
-    (stature/count statsd key))
-  (on-error [this key]
-    (log/warnf "request=%s status=error" key)
-    (stature/count statsd key))
-  (on-failure [this key]
-    (log/errorf "request=%s status=failure" key)
-    (stature/count statsd key))
-  (on-not-found [this key uri]
-    (log/warnf "request=%s status=not-found uri=%s" key uri)
-    (stature/count statsd key))
-  (track-exception [this exception] (log/error exception)
+
+  (record-timing
+    [this key time-ms]
+    (if (should-report? exclude-pattern key)
+      (do
+        (log/infof "request=%s time=%s" key time-ms)
+        (stature/timing statsd key time-ms))
+      (log/debugf "request=%s time=%s" key time-ms)))
+
+
+  (on-success
+    [this key response]
+    (if (should-report? exclude-pattern key)
+      (do
+        (log/infof "request=%s status=success:%s" key (:status response))
+        (stature/count statsd key))
+      (log/debugf "request=%s status=success:%s" key (:status response))))
+
+
+  (on-error
+    [this key]
+    (if (should-report? exclude-pattern key)
+      (do
+        (log/warnf "request=%s status=error" key)
+        (stature/count statsd key))
+      (log/debugf "request=%s status=error" key)))
+
+  (on-failure
+    [this key]
+    (if (should-report? exclude-pattern key)
+      (do
+        (log/errorf "request=%s status=failure" key)
+        (stature/count statsd key))
+      (log/debugf "request=%s status=failure" key)))
+
+  (on-not-found
+    [this key uri]
+    (if (should-report? exclude-pattern key)
+      (do
+        (log/warnf "request=%s status=not-found uri=%s" key uri)
+        (stature/count statsd key))
+      (log/warnf "request=%s status=not-found uri=%s" key uri)))
+
+  (track-exception
+    [this exception]
+    (log/error exception)
     (tracker/report exception-tracker exception))
-  (track-exception [this exception data]
+
+  (track-exception
+    [this exception data]
     (log/errorf exception "data=%s" data)
     (tracker/report exception-tracker exception data)))
 
-(defn create [{:keys [name]}]
-  (map->Monitoring {:name (or name "duckula.monitoring")}))
+
+(defn create
+  [{:keys [name exclude-pattern]}]
+  {:pre [(or (nil? exclude-pattern)
+             (instance? Pattern exclude-pattern))]}
+  (map->Monitoring {:exclude-pattern exclude-pattern
+                    :name (or name "duckula.monitoring")}))

--- a/test/duckula/monitoring_test.clj
+++ b/test/duckula/monitoring_test.clj
@@ -1,36 +1,54 @@
 (ns duckula.monitoring-test
-  (:require [duckula.monitoring :as monitoring]
-            [duckula.protocol :as protocol]
-            [stature.metrics.protocol :as metrics]
-            [caliban.tracker.mock :as tracker.mock]
-            [clojure.test :refer :all]
-            [com.stuartsierra.component :as component]))
+  (:require
+    [caliban.tracker.mock :as tracker.mock]
+    [clojure.test :refer :all]
+    [com.stuartsierra.component :as component]
+    [duckula.monitoring :as monitoring]
+    [duckula.protocol :as protocol]
+    [stature.metrics.protocol :as metrics]))
+
 
 (def counter-state (atom {}))
 
-(defrecord FakeStatsd []
+
+(defrecord FakeStatsd
+  []
+
   component/Lifecycle
+
   (start [this] this)
-  (stop [this]
+
+
+  (stop
+    [this]
     (reset! counter-state {})
     this)
+
+
   metrics/Metrics
-  (count [this key]
+
+  (count
+    [this key]
     (swap! counter-state (fn [c] (update c key #(inc (get % key 0))))))
-  (timing [this key val]
+
+
+  (timing
+    [this key val]
     (swap! counter-state #(assoc % (str key ".ms") val))))
+
 
 (use-fixtures :each (fn [test-fn]
                       (reset! counter-state {})
                       (test-fn)))
 
+
 (deftest monitoring-test
   (let [system (component/start-system
-                {:exception-tracker (tracker.mock/create)
-                 :statsd (->FakeStatsd)
-                 :monitoring (component/using
-                              (monitoring/create {:name "no name"})
-                              [:statsd :exception-tracker])})]
+                 {:exception-tracker (tracker.mock/create)
+                  :statsd (->FakeStatsd)
+                  :monitoring (component/using
+                                (monitoring/create {:name "no name"})
+                                [:statsd :exception-tracker])})]
     (protocol/record-timing (:monitoring system) "test.timing" 100)
     (protocol/on-success (:monitoring system) "test.success" {:status 210})
     (protocol/on-error (:monitoring system) "test.error")
@@ -42,9 +60,38 @@
       (catch Exception err
         (protocol/track-exception (:monitoring system) err)))
     (is (= {"test.error" 1
-    "test.failure" 1
-    "test.not-found" 1
-    "test.success" 1
-    "test.timing.ms" 100}
+            "test.failure" 1
+            "test.not-found" 1
+            "test.success" 1
+            "test.timing.ms" 100}
+           @counter-state))
+    (component/stop system)))
+
+
+(deftest exclusion-test
+  (let [system (component/start-system
+                 {:exception-tracker (tracker.mock/create)
+                  :statsd (->FakeStatsd)
+                  :monitoring (component/using
+                                (monitoring/create {:name "no name" :exclude-pattern #".*health-check"})
+                                [:statsd :exception-tracker])})]
+    (protocol/record-timing (:monitoring system) "test.timing" 100)
+    (protocol/on-success (:monitoring system) "test.success" {:status 210})
+    (protocol/on-success (:monitoring system) "health.success" {:status 210})
+    (protocol/on-success (:monitoring system) "health-check.success" {:status 210})
+    (protocol/on-error (:monitoring system) "test.error")
+    (protocol/on-failure (:monitoring system) "test.failure")
+    (protocol/on-failure (:monitoring system) "test.failure")
+    (protocol/on-not-found (:monitoring system) "test.not-found" "/not-found-yo")
+    (try
+      (throw (ex-info "boo" {}))
+      (catch Exception err
+        (protocol/track-exception (:monitoring system) err)))
+    (is (= {"test.error" 1
+            "test.failure" 1
+            "test.not-found" 1
+            "test.success" 1
+            "health.success" 1
+            "test.timing.ms" 100}
            @counter-state))
     (component/stop system)))


### PR DESCRIPTION
Since it's common to add health check routes to Duckula, these are not useful after a while and produce noise in logs and metrics, if tracking of health check requests is not required.

New `exclude-pattern` option will:

- stop sending statsd metrics for matching keys
- switch logging to DEBUG level for matching keys